### PR TITLE
Pattern matching checked. tests written and passed.

### DIFF
--- a/scala-2.12/src/main/scala/patternmatching/caseclasses/External.scala
+++ b/scala-2.12/src/main/scala/patternmatching/caseclasses/External.scala
@@ -1,0 +1,4 @@
+package io.github.malyszaryczlowiek
+package patternmatching.caseclasses
+
+case class External(internal: Internal = Internal())

--- a/scala-2.12/src/main/scala/patternmatching/caseclasses/Internal.scala
+++ b/scala-2.12/src/main/scala/patternmatching/caseclasses/Internal.scala
@@ -1,0 +1,4 @@
+package io.github.malyszaryczlowiek
+package patternmatching.caseclasses
+
+case class Internal(i: Int = 0)

--- a/scala-2.12/src/main/scala/patternmatching/standardclasses/External.scala
+++ b/scala-2.12/src/main/scala/patternmatching/standardclasses/External.scala
@@ -1,0 +1,15 @@
+package io.github.malyszaryczlowiek
+package patternmatching.standardclasses
+
+class External(val internal: Internal = new Internal())
+object External {
+
+  def unapply(arg: External): Option[Internal] = {
+    println(s"External.unapply() called")
+    Some(arg.internal)
+  }
+
+
+
+}
+

--- a/scala-2.12/src/main/scala/patternmatching/standardclasses/Internal.scala
+++ b/scala-2.12/src/main/scala/patternmatching/standardclasses/Internal.scala
@@ -1,0 +1,12 @@
+package io.github.malyszaryczlowiek
+package patternmatching.standardclasses
+
+class Internal(val i: Int = 0)
+object Internal {
+
+  def unapply(ii:Internal): Option[Int] = {
+    println(s"Internal.unapply() called")
+    Some(ii.i)
+  }
+
+}

--- a/scala-2.12/src/test/scala/patternmatchingtest/caseclassestests/PatternMatchingCaseClassesTests.scala
+++ b/scala-2.12/src/test/scala/patternmatchingtest/caseclassestests/PatternMatchingCaseClassesTests.scala
@@ -1,0 +1,27 @@
+package io.github.malyszaryczlowiek
+package patternmatchingtest.caseclassestests
+
+import patternmatching.caseclasses.{External, Internal}
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class PatternMatchingCaseClassesTests extends AnyFunSuite {
+
+  test("Case classes NEED unapply method of internal classes") {
+    val e = External() // without brackets not compile
+    e match {
+      case External(Internal(i: Int)) =>
+        println(s"internal unapply called. ok i = ${i}")
+        assert(true)
+      case External(internal: Internal) =>
+        println(s"only external unapply called, ok i = ${internal.i}")
+        assert(true)
+      case External(_) =>
+        assert(false, s"not parsing without explicitly defined unapply method")
+      case _ =>
+        assert(false, s"not match to External case class. ")
+
+    }
+  }
+
+}

--- a/scala-2.12/src/test/scala/patternmatchingtest/standardclassestests/PatternMatchingStandardClassesTests.scala
+++ b/scala-2.12/src/test/scala/patternmatchingtest/standardclassestests/PatternMatchingStandardClassesTests.scala
@@ -1,0 +1,38 @@
+package io.github.malyszaryczlowiek
+package patternmatchingtest.standardclassestests
+
+import patternmatching.standardclasses.{External, Internal}
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class PatternMatchingStandardClassesTests extends AnyFunSuite {
+
+  /**
+   * not compile without unapply methods
+   */
+  test("standard classes NEED unapply method of internal classes, but not match in pattern matching") {
+    val e = new External()
+    e match {
+      // this case is not matching but it calls Internal.unapply
+      case External(Internal(i: Int)) =>
+        println(s"calling internal unapply method")
+        assert(true)
+      // this case matches but NOT calls Internal.unapply !!!!
+      case External(internal: Internal) =>
+        println(s"calling external and internal unapply methods but internal not match. ok i = ${internal.i}")
+        assert(true)
+      case External(_) =>
+        assert(false, s"not parsing without explicitly defined unapply method")
+      case _ =>
+        assert(false, s"not match to External case class. ")
+    }
+    /*
+    RESULT: Same scala 2.13
+    External.unapply() called
+    Internal.unapply() called
+    calling internal unapply method
+     */
+  }
+
+
+}

--- a/scala-2.13/src/main/scala/patternmatching/caseclasses/External.scala
+++ b/scala-2.13/src/main/scala/patternmatching/caseclasses/External.scala
@@ -1,0 +1,4 @@
+package io.github.malyszaryczlowiek
+package patternmatching.caseclasses
+
+case class External(internal: Internal = Internal())

--- a/scala-2.13/src/main/scala/patternmatching/caseclasses/Internal.scala
+++ b/scala-2.13/src/main/scala/patternmatching/caseclasses/Internal.scala
@@ -1,0 +1,4 @@
+package io.github.malyszaryczlowiek
+package patternmatching.caseclasses
+
+case class Internal(i: Int = 0)

--- a/scala-2.13/src/main/scala/patternmatching/standardclasses/External.scala
+++ b/scala-2.13/src/main/scala/patternmatching/standardclasses/External.scala
@@ -1,0 +1,15 @@
+package io.github.malyszaryczlowiek
+package patternmatching.standardclasses
+
+class External(val internal: Internal = new Internal())
+object External {
+
+  def unapply(arg: External): Option[Internal] = {
+    println(s"External.unapply() called")
+    Some(arg.internal)
+  }
+
+
+
+}
+

--- a/scala-2.13/src/main/scala/patternmatching/standardclasses/Internal.scala
+++ b/scala-2.13/src/main/scala/patternmatching/standardclasses/Internal.scala
@@ -1,0 +1,14 @@
+package io.github.malyszaryczlowiek
+package patternmatching.standardclasses
+
+class Internal(val i: Int = 0)
+object Internal {
+
+  // slightly modified unapply method
+  def unapply(ii:Internal): Option[Int] = {
+    println(s"Internal.unapply() called")
+    Some(ii.i)
+  }
+
+
+}

--- a/scala-2.13/src/test/scala/patternmatchingtest/caseclassestests/PatternMatchingCaseClassesTests.scala
+++ b/scala-2.13/src/test/scala/patternmatchingtest/caseclassestests/PatternMatchingCaseClassesTests.scala
@@ -1,0 +1,27 @@
+package io.github.malyszaryczlowiek
+package patternmatchingtest.caseclassestests
+
+import patternmatching.caseclasses.{External, Internal}
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class PatternMatchingCaseClassesTests extends AnyFunSuite {
+
+  test("Case classes NEED unapply method of internal classes") {
+    val e = External() // without brackets not compile
+    e match {
+      case External(Internal(i: Int)) =>
+        println(s"internal unapply called. ok i = ${i}")
+        assert(true)
+      case External(internal: Internal) =>
+        println(s"only external unapply called, ok i = ${internal.i}")
+        assert(true)
+      case External(_) =>
+        assert(false, s"not parsing without explicitly defined unapply method")
+      case _ =>
+        assert(false, s"not match to External case class. ")
+
+    }
+  }
+
+}

--- a/scala-2.13/src/test/scala/patternmatchingtest/standardclassestests/PatternMatchingStandardClassesTests.scala
+++ b/scala-2.13/src/test/scala/patternmatchingtest/standardclassestests/PatternMatchingStandardClassesTests.scala
@@ -1,0 +1,42 @@
+package io.github.malyszaryczlowiek
+package patternmatchingtest.standardclassestests
+
+import patternmatching.standardclasses.{External, Internal}
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class PatternMatchingStandardClassesTests extends AnyFunSuite {
+
+  /**
+   * not compile without unapply methods
+   */
+  test("standard classes NEED unapply method of internal classes, but not match in pattern matching") {
+    val e = new External()
+    e match {
+      // this case is not matching but it calls Internal.unapply
+      case External(Internal(i: Int)) =>
+        println(s"calling internal unapply method")
+        assert(true)
+      // this case matches but NOT calls Internal.unapply !!!!
+      case External(internal: Internal) =>
+        println(s"calling external and internal unapply methods but internal not match. ok i = ${internal.i}")
+        assert(true)
+      case External(_) =>
+        assert(false, s"not parsing without explicitly defined unapply method")
+      case _ =>
+        assert(false, s"not match to External case class. ")
+    }
+
+
+    /*
+    RESULT: Same scala 2.12
+    External.unapply() called
+    Internal.unapply() called
+    calling internal unapply method
+    */
+
+
+  }
+
+
+}

--- a/scala-31/src/main/scala/patternmatching/caseclasses/External.scala
+++ b/scala-31/src/main/scala/patternmatching/caseclasses/External.scala
@@ -1,0 +1,6 @@
+package io.github.malyszaryczlowiek
+package patternmatching.caseclasses
+
+
+
+case class External(internal: Internal = Internal())

--- a/scala-31/src/main/scala/patternmatching/caseclasses/Internal.scala
+++ b/scala-31/src/main/scala/patternmatching/caseclasses/Internal.scala
@@ -1,0 +1,4 @@
+package io.github.malyszaryczlowiek
+package patternmatching.caseclasses
+
+case class Internal(i: Int = 0)

--- a/scala-31/src/main/scala/patternmatching/standardclasses/External.scala
+++ b/scala-31/src/main/scala/patternmatching/standardclasses/External.scala
@@ -1,0 +1,12 @@
+package io.github.malyszaryczlowiek
+package patternmatching.standardclasses
+
+class External(val internal: Internal = new Internal())
+object External {
+
+  def unapply(arg: External): Option[Internal] =
+    println(s"External.unapply() called")
+    Some(arg.internal)
+
+}
+

--- a/scala-31/src/main/scala/patternmatching/standardclasses/Internal.scala
+++ b/scala-31/src/main/scala/patternmatching/standardclasses/Internal.scala
@@ -1,0 +1,11 @@
+package io.github.malyszaryczlowiek
+package patternmatching.standardclasses
+
+class Internal(val i: Int = 0)
+object Internal {
+
+  def unapply(ii:Internal): Option[Int] =
+    println(s"Internal.unapply() called")
+    Some(ii.i)
+
+}

--- a/scala-31/src/test/scala/patternmatchingtest/caseclassestests/PatternMatchingCaseClassesTests.scala
+++ b/scala-31/src/test/scala/patternmatchingtest/caseclassestests/PatternMatchingCaseClassesTests.scala
@@ -1,0 +1,25 @@
+package io.github.malyszaryczlowiek
+package patternmatchingtest.caseclassestests
+
+import patternmatching.caseclasses.{External, Internal}
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class PatternMatchingCaseClassesTests extends AnyFunSuite {
+
+  test("Case classes NEED unapply method of internal classes") {
+    val e = External() // without brackets not compile
+    e match
+      case External(Internal(i: Int)) =>
+        println(s"internal unapply called. ok i = ${i}")
+        assert(true)
+      case External(internal: Internal) =>
+        println(s"only external unapply called, ok i = ${internal.i}")
+        assert(true)
+      case External(_) =>
+        assert(false, s"not parsing without explicitly defined unapply method")
+      case _ =>
+        assert(false, s"not match to External case class. ")
+  }
+
+}

--- a/scala-31/src/test/scala/patternmatchingtest/standardclassestests/PatternMatchingStandardClassesTests.scala
+++ b/scala-31/src/test/scala/patternmatchingtest/standardclassestests/PatternMatchingStandardClassesTests.scala
@@ -1,0 +1,40 @@
+package io.github.malyszaryczlowiek
+package patternmatchingtest.standardclassestests
+
+import patternmatching.standardclasses.{External, Internal}
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class PatternMatchingStandardClassesTests extends AnyFunSuite {
+
+  /**
+   * not compile without unapply methods
+   */
+  test("standard classes NEED unapply method of internal classes, but not match in pattern matching") {
+    val e = new External()
+    e match
+      // this case is not matching but it calls Internal.unapply
+      case External(Internal(i: Int)) =>
+        println(s"calling internal unapply method")
+        assert(true)
+      // this case matches but NOT calls Internal.unapply !!!!
+      case External(internal: Internal) =>
+        println(s"calling external and internal unapply methods but internal not match. ok i = ${internal.i}")
+        assert(true)
+      case External(_) =>
+        assert(false, s"not parsing without explicitly defined unapply method")
+      case _ =>
+        assert(false, s"not match to External case class. ")
+
+    /*
+    RESULT:
+    External.unapply() called
+    Internal.unapply() called
+    calling internal unapply method
+    */
+
+
+  }
+
+
+}


### PR DESCRIPTION
Conclusions. Standard classes need unapply methods. But if we do not check internal structure of arguments, unapply methods of this arguments is not called. 